### PR TITLE
The syntax for the template was invalid

### DIFF
--- a/static/javascript/auto/cookieconsent_config.js.tmpl
+++ b/static/javascript/auto/cookieconsent_config.js.tmpl
@@ -102,7 +102,7 @@ window.addEventListener('load', function(){
                                     is_regex: true
                                 },
                                 {
-                                    col1: 'eprints_doc_request'
+                                    col1: 'eprints_doc_request',
                                     col2: 'oars.uos.ac.uk',
                                     col3: 'session',
                                     col4: 'Provide approved temporary access to restricted document'


### PR DESCRIPTION
So if you (like me) blindly copied the template the javascript would be invalid and the popup never pops up.

Added a comma.